### PR TITLE
Write version to setup.py for publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
             sudo pip install pipenv
             pipenv install
             pipenv run pip install requests
+            pipenv run pip install -e .
       - run:
           name: Run tests
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.1.3] - 2021-07-14
+### Changed
+- No-op. Previous publish broke package installation.
+
 ## [0.1.2] - 2021-07-13
 ### Changed
 - No-op. Publishing old `wayscript` package under new name.
@@ -27,7 +31,8 @@ All notable changes to this project will be documented in this file.
 ## [0.0.1] - 2019-04-17
 ### Released SDK
 
-[Unreleased]: https://github.com/wayscript/wayscript-python-legacy/compare/0.1.2...HEAD
+[Unreleased]: https://github.com/wayscript/wayscript-python-legacy/compare/0.1.3...HEAD
+[0.1.3]: https://github.com/wayscript/wayscript-python-legacy/compare/0.1.2...0.1.3
 [0.1.2]: https://github.com/wayscript/wayscript-python-legacy/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/wayscript/wayscript-python-legacy/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/wayscript/wayscript-python-legacy/compare/0.0.3...0.1.0

--- a/files/usr/local/bin/publish.sh
+++ b/files/usr/local/bin/publish.sh
@@ -3,11 +3,17 @@
 set -e
 set -x
 
+PROJECT_DIR=/usr/local/src/project
+
 # set version here. tag-version will blow the script up if it is not a clean working copy.
 VERSION=$(tag-version)
 export VERSION=$VERSION
 echo $VERSION
 
-DIST_DIR=/usr/local/src/project/dist
+VERSION_PLACEHOLDER="version='0.0.0',"
+sed -i "s/$VERSION_PLACEHOLDER/version='$VERSION',/" $PROJECT_DIR/setup.py
+
+
+DIST_DIR=$PROJECT_DIR/dist
 python setup.py sdist --dist-dir $DIST_DIR
 twine upload dist/wayscript-legacy-$VERSION.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -9,16 +9,10 @@ import os
 with open("README.md", "r", encoding="UTF-8") as fh:
     long_description = fh.read()
 
-def get_version():
-    """Helper method to retrieve current version"""
-    version = os.environ["VERSION"]
-    # ToDo: add assertions to ensure that this is a valid, publishable version
-    return version
-
 
 setuptools.setup(
     name="wayscript-legacy",
-    version=get_version(),
+    version='0.0.0',
     author="Team WayScript",
     author_email="founders@wayscript.com",
     description="WayScript gives you flexible building blocks to seamlessly integrate, automate and host tools in the cloud.",


### PR DESCRIPTION
## Change description

Borked versioning in `setup.py`. When attempting to install `wayscript-legacy` it required a `VERSION` environment variable to be present matching a version in pypi. With this change we write a version to `setup.py` before publishing rather than relying on an environment variable.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
